### PR TITLE
Stop seeing farther in the diagonals / Apply Fog in a radius from camera

### DIFF
--- a/MultiColorFog/MultiColorFog.shader
+++ b/MultiColorFog/MultiColorFog.shader
@@ -16,7 +16,7 @@ void fragment() {
 	vec3 ndc= vec3(SCREEN_UV, depth) * 2.0 - 1.0;
 	vec4 view = INV_PROJECTION_MATRIX* vec4(ndc, 1.0);
 	view.xyz /= view.w;
-	depth = -view.z;
+	depth = length(view.xyz);
 	
 	float fog = depth * fog_amount;
 	


### PR DESCRIPTION
Changes the fog so that you cannot see farther in the diagonals, but so that it is applied in a radius and has the same visibility falloff in all directions.